### PR TITLE
Add ECR permissions

### DIFF
--- a/manual/template.json
+++ b/manual/template.json
@@ -246,6 +246,25 @@
                 "cloudformation:GetTemplateSummary"
               ],
               "Resource": "*"
+            },
+            {
+              "Action": [
+                "ecr:GetAuthorizationToken",
+                "ecr:CreateRepository",
+                "ecr:TagResource",
+                "ecr:DescribeRepositories",
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:ListImages",
+                "ecr:DescribeImages",
+                "ecr:BatchGetImage",
+                "ecr:InitiateLayerUpload",
+                "ecr:UploadLayerPart",
+                "ecr:CompleteLayerUpload",
+                "ecr:PutImage"
+              ],
+              "Effect": "Allow",
+              "Resource": "*"
             }
           ]
         }


### PR DESCRIPTION
This lets account-controllers manage ECR repositories in user provided AWS accounts.

Part of https://github.com/acorn-io/hub/issues/302