### PR TITLE
Add iam:ListPolicyRole to the allowed actions

### DIFF
--- a/template/template-v1.json
+++ b/template/template-v1.json
@@ -214,7 +214,8 @@
                 "iam:AddClientIDToOpenIDConnectProvider",
                 "iam:RemoveClientIDFromOpenIDConnectProvider",
                 "iam:GetPolicy",
-                "iam:DeletePolicy"
+                "iam:DeletePolicy",
+                "iam:ListPolicyVersions"
               ],
               "Resource": "*"
             },


### PR DESCRIPTION
@thedadams asked me to look into this.

When we try to delete the very stack created by this template, currently the AcornManagedPolicy fails to delete with this error message:

```
API: iam:ListPolicyVersions User: arn:aws:sts::223342718081:assumed-role/acorn-g-linville-AcornRole-IJWXE4PI8JCN/userstack,aws is not authorized to perform: iam:ListPolicyVersions on resource: policy arn:aws:iam::223342718081:policy/acorn-g-linville-AcornManagedPolicy-1J3TYY5GYN4WV because no identity-based policy allows the iam:ListPolicyVersions action
```

So let's try adding that to the allowed actions.