### PR TITLE
Add more permission to delete account stack

### DIFF
--- a/template/template-v1.json
+++ b/template/template-v1.json
@@ -233,7 +233,8 @@
                 "iam:DeletePolicy",
                 "iam:ListPolicyVersions",
                 "iam:UpdateAssumeRolePolicy",
-                "iam:TagOpenIDConnectProvider"
+                "iam:TagOpenIDConnectProvider",
+                "iam:DeletePolicyVersion"
               ],
               "Resource": "*"
             },


### PR DESCRIPTION
Account stack fail to be deleted because of this error

```
API: iam:DeletePolicyVersion User: arn:aws:sts::813797352263:assumed-role/strongmonkey-447e992f3eb5-aws-AcornRole-UJ2NMEGJMXQS/userstack,aws is not authorized to perform: iam:DeletePolicyVersion on resource: policy arn:aws:iam::813797352263:policy/strongmonkey-447e992f3eb5-aws-AcornManagedPolicy2-1D690Z9LRYSDD because no identity-based policy allows the iam:DeletePolicyVersion action
```