### PR TITLE
Make sure acornRole is created first

### DIFF
--- a/template/template-v1.json
+++ b/template/template-v1.json
@@ -315,6 +315,7 @@
     },
     "AcornLambdaRole": {
       "Type": "AWS::IAM::Role",
+      "DependsOn" : "AcornRole",
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17",


### PR DESCRIPTION
When account cloudformation stack is deleted, the acornRole needs to be deleted at last, otherwise we won't be able to assume the current role to delete other resources. Cloudformation stack deletes thing in reverse order so that we need to make sure acornRole is created first by adding dependOn. 

https://github.com/acorn-io/manager/issues/941