### PR TITLE
Update to use latest provided.al2 runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 package:
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o aws-registration-callback main.go
-	zip aws-registration-callback.zip aws-registration-callback
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o bootstrap main.go
+	zip aws-registration-callback.zip bootstrap

--- a/template/template-v1.json
+++ b/template/template-v1.json
@@ -352,7 +352,7 @@
             "Arn"
           ]
         },
-        "Runtime": "go1.x",
+        "Runtime": "provided.al2",
         "Handler": "aws-registration-callback",
         "Code": {
           "S3Bucket": "BUCKET",


### PR DESCRIPTION
AWS is deprecating go1.x runtime and we need to bump it soon before it stops working.

https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/