### PR TITLE
Add permissions to allow account stack to update its own permission

### DIFF
--- a/template/template-v1.json
+++ b/template/template-v1.json
@@ -238,7 +238,8 @@
                 "iam:ListOpenIDConnectProviderTags",
                 "iam:UntagOpenIDConnectProvider",
                 "iam:TagRole",
-                "iam:GetInstanceProfile"
+                "iam:GetInstanceProfile",
+                "iam:CreatePolicyVersion"
               ],
               "Resource": "*"
             },


### PR DESCRIPTION
We need this permission to be able to update its own permission. Sometimes when stack gets new permission the role needs to be able to update itself.